### PR TITLE
Use vint to lint vim script

### DIFF
--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -1,0 +1,3 @@
+policies:
+  ProhibitUnnecessaryDoubleQuote:
+    enabled: false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ An up-to-date Vim syntax for PHP.
 
 _This project is a fork of [php.vim--Garvin][php.vim-garvin] which in turn is an update of the [php.vim][php.vim-original] script which in turn is an updated version of the php.vim syntax file distributed with Vim. **Whew!**_
 
+Versions
+--------
+
+`php.vim` should work with Vim 5.4 and newer. Performance improvements target Vim 7.4 and newer.
+
+Also works with other flavours like NeoVim.
+
 Installation
 ------------
 

--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -1041,7 +1041,7 @@ let b:current_syntax = "php"
 let &iskeyword = s:iskeyword_save
 unlet s:iskeyword_save
 
-if (exists("main_syntax") && main_syntax == 'php')
+if (exists("main_syntax") && main_syntax ==# 'php')
   unlet main_syntax
 endif
 

--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -657,7 +657,7 @@ if !exists("php_ignore_phpdoc") || !php_ignore_phpdoc
   syn case match
 endif
 
-if version >= 600
+if v:version >= 600
   syn match phpComment  "#.\{-}\(?>\|$\)\@="  contained contains=phpTodo,@Spell
   syn match phpComment  "//.\{-}\(?>\|$\)\@=" contained contains=phpTodo,@Spell
 else
@@ -681,7 +681,7 @@ endif
 syn case match
 
 " HereDoc
-if version >= 704
+if v:version >= 704
   if b:php_version_id >= 70300
     " @begin phpHereDoc_php73
     SynFold syn region phpHereDoc matchgroup=Delimiter start="\(<<<\)\@3<=\s*\z(\I\i*\)$" end="^\s*\z1\>" contained contains=@Spell,phpIdentifier,phpIdentifierSimply,phpIdentifierComplex,phpSpecialChar,phpMethodsVar,phpStrEsc keepend extend
@@ -752,7 +752,7 @@ else
 endif
 
 " NowDoc
-if version >= 704
+if v:version >= 704
   if b:php_version_id >= 70300
     " @begin phpNowDoc_php73
     SynFold syn region phpNowDoc matchgroup=Delimiter start=+\(<<<\)\@3<=\s*'\z(\I\i*\)'$+ end="^\s*\z1\>" contained keepend extend


### PR DESCRIPTION
* Ignore double quotes vs single quotes
* Use `v:version` to refer to the vim version (`version` is for backwards-compatibility with vim before 5.4).
* Use `==#` to compare equality matching case (as `php.vim` controls the value compared against).