### PR TITLE
Prevent attributes from being marked as a comment

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -686,15 +686,8 @@ if !exists("php_ignore_phpdoc") || !php_ignore_phpdoc
   syn case match
 endif
 
-if v:version >= 600
-  syn match phpComment  "#.\{-}\(?>\|$\)\@="  contained contains=phpTodo,@Spell
-  syn match phpComment  "//.\{-}\(?>\|$\)\@=" contained contains=phpTodo,@Spell
-else
-  syn match phpComment  "#.\{-}$" contained contains=phpTodo,@Spell
-  syn match phpComment  "#.\{-}?>"me=e-2  contained contains=phpTodo,@Spell
-  syn match phpComment  "//.\{-}$"  contained contains=phpTodo,@Spell
-  syn match phpComment  "//.\{-}?>"me=e-2 contained contains=phpTodo,@Spell
-endif
+syn match phpComment  "#.\{-}\(?>\|$\)\@="  contained contains=phpTodo,@Spell
+syn match phpComment  "//.\{-}\(?>\|$\)\@=" contained contains=phpTodo,@Spell
 
 " String
 if (exists("php_parent_error_open") && php_parent_error_open)

--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -686,7 +686,7 @@ if !exists("php_ignore_phpdoc") || !php_ignore_phpdoc
   syn case match
 endif
 
-syn match phpComment  "#.\{-}\(?>\|$\)\@="  contained contains=phpTodo,@Spell
+syn match phpComment  "#\[\@!.\{-}\(?>\|$\)\@="  contained contains=phpTodo,@Spell
 syn match phpComment  "//.\{-}\(?>\|$\)\@=" contained contains=phpTodo,@Spell
 
 " String


### PR DESCRIPTION
Although it seems to work fine without this change, make sure Attributes `#[...]` are not identified as comments.