### PR TITLE
Allow Attributes in parameter lists

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -902,7 +902,7 @@ syn keyword phpKeyword function contained
 syn match phpFunction /\h\w*/ contained
 
 " PHP 8 Attribute
-syn region phpAttribute matchgroup=Delimiter start="^\s*#\[" end="\]$" contained display contains=@phpClConst,phpParent,phpParentError transparent
+syn region phpAttribute matchgroup=Delimiter start="#\[" end="\]" contained display contains=@phpClConst,phpParent,phpParentError transparent
 
 " PHP 7 Generator & delegation via yield from
 "


### PR DESCRIPTION
Remove the anchors for Attributes as they may also appear before parameters.

Example (`SensitiveParameter` attribute is added in PHP 8.2, but parameter attributes are supported from PHP 8.0):

```php
public function hash(#[SensitiveParameter] string $password) {
    debug_print_backtrace();
}
```