### PR TITLE
Support variable variables in strings

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -600,8 +600,8 @@ syn match phpMethod /\h\w*/ contained
 syn match phpSplatOperator  "\.\.\." contained display
 
 " Identifier
-syn match  phpIdentifier         "$\h\w*"  contained contains=phpSuperglobals,phpVarSelector display
-syn match  phpIdentifierSimply   "${\h\w*}"  contains=phpOperator,phpParent  contained display
+syn match  phpIdentifier         "$$\?\h\w*"  contained contains=phpSuperglobals,phpVarSelector display
+syn match  phpIdentifierSimply   "${$\?\h\w*}"  contains=phpOperator,phpParent  contained display
 syn region phpIdentifierComplex  matchgroup=phpParent start="{\$"rs=e-1 end="}"  contains=phpIdentifier,phpIdentifierSimply,phpSpecialChar,phpMethodsVar,phpStringSingle,phpStringDouble,phpBacktick,phpStrEsc contained extend
 
 " Boolean


### PR DESCRIPTION
Allow `${$var}` and `{$$var}` syntax to be highlighted inside double quoted strings.

Examples:

```php
echo "Hello {$var} and ${var}"; // plain variables still work
echo "Hello {$$var} and ${$var}";
echo <<<HERE
  Hello {$$var} and ${$var}
HERE;
echo <<<"HERE"
  Hello {$$var} and ${$var}
HERE;
echo `echo '{$$var} and ${$var}'`;

echo 'Hello {$$var} and ${var}'; // does not highlight in single-quoted string
echo <<<'NOW'
  Hello {$$var} and ${$var} - does not highlight in a nowdoc
NOW;
```

## Screenshot with this change

![variable_variables_in_string](https://github.com/biinari/php.vim/assets/148009/4a3345ce-abe5-42fd-8d2b-283c8297c6c7)
